### PR TITLE
Feature/issue 126 developer config

### DIFF
--- a/src/dev_config.json
+++ b/src/dev_config.json
@@ -1,0 +1,78 @@
+{
+    "domain_objects" : [
+        {
+            "instrument" : {
+                "module_name" : "instrument",
+                "class_name" : "Instrument"
+            },
+            "counterparty" : {
+                "module_name" : "counterparty",
+                "class_name" : "Counterparty"
+            },
+            "back_office_position" : {
+                "module_name": "back_office_position",
+                "class_name": "BackOfficePosition"
+            },
+            "cash_balance" : {
+                "module_name": "cash_balance",
+                "class_name": "CashBalance"
+            },
+            "depot_position" : {
+                "module_name": "depot_position",
+                "class_name": "DepotPosition"
+            },
+            "front_office_position" : {
+                "module_name": "front_office_position",
+                "class_name": "FrontOfficePosition"
+            },
+            "order_execution" : {
+                "module_name": "order_execution",
+                "class_name": "OrderExecution"
+            },
+            "price" : {
+                "module_name": "price",
+                "class_name": "Price"
+            },
+            "stock_loan_position" : {
+                "module_name": "stock_loan_position",
+                "class_name": "StockLoanPosition"
+            },
+            "swap_contract" : {
+                "module_name": "swap_contract",
+                "class_name": "SwapContract"
+            },
+            "swap_position" : {
+                "module_name": "swap_position",
+                "class_name": "SwapPosition"
+            },
+            "cashflow" : {
+                "module_name": "cashflow",
+                "class_name": "Cashflow"
+            }
+        }
+    ],
+    "file_builders" : [
+        {
+            "CSV" : {
+                "module_name": "csv_builder",
+                "class_name": "CSVBuilder",
+                "file_extension": ".csv"
+            },
+            "JSON" : {
+                "module_name": "json_builder",
+                "class_name": "JSONBuilder",
+                "file_extension": ".json"
+            },
+            "XML" : {
+                "module_name": "xml_builder",
+                "class_name": "XMLBuilder",
+                "file_extension": ".xml"
+            },
+            "JSONL" : {
+                "module_name": "jsonl_builder",
+                "class_name": "JSONLBuilder",
+                "file_extension": ".jsonl"
+            }
+        }
+    ]
+}

--- a/src/example-config.json
+++ b/src/example-config.json
@@ -1,280 +1,59 @@
-{ "domain_objects" : [
-    {
-        "module_name":"instrument",
-        "class_name":"Instrument",
-        "record_count":"100000",
-        "max_objects_per_file":"50000",
-        "file_name":"instruments",
-        "root_element_name":"instruments",
-        "item_name":"instrument",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false",
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],
-        "custom_args":{}
-    },
-    {
-        "module_name":"counterparty",
-        "class_name":"Counterparty",
-        "record_count":"1500",
-        "max_objects_per_file":"50000",
-        "file_name":"counterparties",
-        "root_element_name":"counterparties",
-        "item_name":"counterparty",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false", 
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],       
-        "custom_args":{}
-    },
-    {
-        "module_name":"back_office_position",
-        "class_name":"BackOfficePosition",
-        "record_count":"0",
-        "max_objects_per_file":"500000",
-        "file_name":"back_office_positions",
-        "root_element_name":"back_office_positions",
-        "item_name":"back_office_position",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false",
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],        
-        "custom_args":{}
-    },
-    {
-        "module_name":"cash_balance",
-        "class_name":"CashBalance",
-        "record_count":"0",
-        "max_objects_per_file":"500000",
-        "file_name":"cash_balances",
-        "root_element_name":"cash_balances",
-        "item_name":"cash_balance",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false",    
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],    
-        "custom_args":{}
-    },
-    {
-        "module_name":"depot_position",
-        "class_name":"DepotPosition",
-        "record_count":"0",
-        "max_objects_per_file":"500000",
-        "file_name":"depot_positions",
-        "root_element_name":"depot_positions",
-        "item_name":"depot_position",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false",   
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],     
-        "custom_args":{}
-    },
-    {
-        "module_name":"front_office_position",
-        "class_name":"FrontOfficePosition",
-        "record_count":"0",
-        "max_objects_per_file":"500000",
-        "file_name":"front_office_positions",
-        "root_element_name":"front_office_positions",
-        "item_name":"front_office_position",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false",    
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],    
-        "custom_args":{}
-    },  
-    {
-        "module_name":"order_execution",
-        "class_name":"OrderExecution",
-        "record_count":"0",
-        "max_objects_per_file":"500000",
-        "file_name":"order_executions",
-        "root_element_name":"order_executions",
-        "item_name":"order_execution",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false", 
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],       
-        "custom_args":{}
-    },
-    {
-        "module_name":"price",
-        "class_name":"Price",
-        "record_count":"0",
-        "max_objects_per_file":"500000",
-        "file_name":"prices",
-        "root_element_name":"prices",
-        "item_name":"price",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false", 
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],       
-        "custom_args":{}
-    },
-    {
-        "module_name":"stock_loan_position",
-        "class_name":"StockLoanPosition",
-        "record_count":"0",
-        "max_objects_per_file":"500000",
-        "file_name":"stock_loan_positions",
-        "root_element_name":"stock_loan_positions",
-        "item_name":"stock_loan_position",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false", 
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],       
-        "custom_args":{}
-    },
-    {
-        "module_name":"swap_contract",
-        "class_name":"SwapContract",
-        "record_count":"1",
-        "max_objects_per_file":"500000",
-        "file_name":"swap_contracts",
-        "root_element_name":"swap_contracts",
-        "item_name":"swap_contract",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false",        
-        "custom_args":{"swap_per_counterparty": {"min":"1", "max":"10"}},
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],
-        "dependencies":["counterparty"]
-    },
-    {
-        "module_name":"swap_position",
-        "class_name":"SwapPosition",
-        "record_count":"1",
-        "max_objects_per_file":"100000",
-        "file_name":"swap_positions",
-        "root_element_name":"swap_positions",
-        "item_name":"swap_position",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "batch_size":10000,
-        "upload_to_google_drive":"false",     
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],   
-        "custom_args": {
-            "start_date":"20190901", 
-            "ins_per_swap": {"min":"1", "max":"10"}
+{
+    "domain_objects" : [
+        {
+            "fixed_object" : {
+                "max_objects_per_file" : 1,
+                "file_name" : "instruments",
+                "output_file_type": "CSV",
+                "output_directory": "path/to/directory",
+                "generation_type": "fixed",
+                "fixed_args" : {
+                    "record_count" : 1
+                },
+                "dummy_data_fields":[
+                    {
+                        "data_type": "type",
+                        "field_count": 1
+                    },
+                    {
+                        "data_type": "type",
+                        "field_count": 1
+                    }
+                ]
+            }
+        },
+        {
+            "variable_object" : {
+                "max_objects_per_file" : 1,
+                "file_name" : "position",
+                "output_file_type": "XML",
+                "output_directory": "path/to/directory",
+                "generation_type": "variable",
+                "variable_args": {
+                    "dependent_object_1" : 1,
+                    "dependent_object_2" : 1,
+                    "generation_chance" : "probability"
+                },
+                "dummy_data_fields":[
+                    {
+                        "data_type": "type",
+                        "field_count": 1
+                    },
+                    {
+                        "data_type": "type",
+                        "field_count": 1
+                    }
+                ],
+                "file_type_args" : {
+                    "xml_root_element" : "positions",
+                    "xml_item_name" : "position"
+                }
+            }
         }
-    },
-    {
-        "module_name":"cashflow",
-        "class_name":"Cashflow",
-        "record_count":"1",
-        "max_objects_per_file":"100000",
-        "file_name":"cashflows",
-        "root_element_name":"cashflows",
-        "item_name":"cashflow",
-        "file_builder_name":"JSONL",
-        "output_directory":"out",
-        "upload_to_google_drive":"false",
-        "batch_size":10000,    
-        "dummy_fields":[
-            { "data_type": "string", "field_count" : "50" },
-            { "data_type": "numeric", "field_count" : "50" }
-        ],       
-        "custom_args": { "start_date":"20190901", 
-            "cashflow_generation" : [
-            {
-                "cashFlowType": "INT_1",
-                "cashFlowAccrual": "DAILY",
-                "cashFlowAccrualProbability": 100,
-                "cashFlowPaydatePeriod": "END_OF_MONTH"
-            },
-            {
-                "cashFlowType": "INT_2",
-                "cashFlowAccrual": "DAILY",
-                "cashFlowAccrualProbability": 100,
-                "cashFlowPaydatePeriod": "END_OF_MONTH"
-            },
-            {
-                "cashFlowType": "DIV",
-                "cashFlowAccrual": "QUARTERLY",
-                "cashFlowAccrualProbability": 100,
-                "cashFlowPaydatePeriod": "END_OF_HALF"
-            },
-            {
-                "cashFlowType": "XYZ",
-                "cashFlowAccrual": "DAILY",
-                "cashFlowAccrualProbability": 100,
-                "cashFlowPaydatePeriod": "END_OF_HALF"
-            },
-            {
-                "cashFlowType": "EQUITY_PN_L_1",
-                "cashFlowAccrual": "CHANCE_ACCRUAL",
-                "cashFlowAccrualProbability": 60,
-                "cashFlowPaydatePeriod": "END_OF_MONTH"
-            },
-            {
-                "cashFlowType": "EQUITY_PN_L_1",
-                "cashFlowAccrual": "CHANCE_ACCRUAL",
-                "cashFlowAccrualProbability": 40,
-                "cashFlowPaydatePeriod": "END_OF_MONTH"
-            }]
-        }
-    }
-
-],
-"shared_domain_object_args" : [
-    { "start_date" : "20190901" }
-],
-"file_builders" : [
-    {
-        "name" : "CSV",
-        "module_name":"csv_builder",
-        "class_name":"CSVBuilder",
-        "file_extension":".csv"        
-    },
-    {
-        "name" : "JSON",
-        "module_name":"json_builder",
-        "class_name":"JSONBuilder",
-        "file_extension":".json"        
-    },
-    {
-        "name" : "XML",
-        "module_name":"xml_builder",
-        "class_name":"XMLBuilder",
-        "file_extension":".xml"        
-    },
-    {
-        "name" : "JSONL",
-        "module_name":"jsonl_builder",
-        "class_name":"JSONLBuilder",
-        "file_extension":".jsonl"        
-    }
-]}
+    ],
+	"shared_generation_arguments" : {
+		"generator_pool_size" : 1,
+		"writer_pool_size" : 1,
+		"pool_job_size" : 1
+	}
+}


### PR DESCRIPTION
Closes: #126 

Moved all developer-centric configuration options into an example-config.json. Fields pre-populated to contain the relevant details.