### PR TITLE
feature/issue-161 changed importlib-metadata version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.0
 httplib2==0.11.3
 idna==2.8
-importlib-metadata==0.17
+importlib-metadata==0.23
 isort==4.3.20
 jsonlines==1.2.0
 kafka-python==1.4.3


### PR DESCRIPTION
closes #161 

all tests pass upon running

```
pip install -r requirements.txt
pytest
```

in the cmd line