### PR TITLE
feature/issue-162: remove instantiate_record

### DIFF
--- a/src/domainobjects/cashflow.py
+++ b/src/domainobjects/cashflow.py
@@ -4,6 +4,7 @@ import pandas as pd
 from datetime import datetime, date
 import calendar
 
+
 class Cashflow(Generatable):
     """ Class to generate cashflows. Generate method will generate a set
     amount of cashflows. Other generation methods are included where cashflows
@@ -65,21 +66,19 @@ class Cashflow(Generatable):
         probability = cf_arg['cashFlowAccrualProbability']
         effective_date = self.effective_date(swap_position['effective_date'])
         if self.cashflow_accrues(effective_date, accrual, probability):
-            record = self.instantiate_record()
-
             pay_date_period = cf_arg['cashFlowPaydatePeriod']
             p_date_func = self.get_pay_date_func(pay_date_period)
-            record['effective_date'] = effective_date
-            record['swap_contract_id'] = swap_position['swap_contract_id']
-            record['ric'] = swap_position['ric']
-            record['long_short'] = swap_position['long_short']
-            record['cashflow_type'] = cf_arg['cashFlowType']
-            record['pay_date'] = datetime.strftime(p_date_func(effective_date),
-                                                   '%Y-%m-%d')
-            record['currency'] = self.generate_currency()
-            record['amount'] = self.generate_random_integer()
-
-            return record
+            return {
+                'swap_contract_id': swap_position['swap_contract_id'],
+                'ric': swap_position['ric'],
+                'cashflow_type': cf_arg['cashFlowType'],
+                'pay_date': datetime.strftime(p_date_func(effective_date),
+                                              '%Y-%m-%d'),
+                'effective_date': effective_date,
+                'currency': self.generate_currency(),
+                'amount': self.generate_random_integer(),
+                'long_short': swap_position['long_short']
+            }
 
     def effective_date(self, effective_date):
         """ Parse string time into Datetime type
@@ -161,8 +160,8 @@ class Cashflow(Generatable):
         """
 
         return {
-            "END_OF_MONTH":self.calc_eom,
-            "END_OF_HALF":self.calc_eoh
+            "END_OF_MONTH": self.calc_eom,
+            "END_OF_HALF": self.calc_eoh
         }.get(pay_date_period, lambda: "Invalid pay date period")
 
     def cashflow_accrues(self, effective_date, accrual, probability):
@@ -193,15 +192,3 @@ class Cashflow(Generatable):
         elif accrual == "CHANCE_ACCRUAL" and \
                 random.random() < (int(probability) / 100):
             return True
-
-    def instantiate_record(self):
-        return {
-            'swap_contract_id': None,
-            'ric': None,
-            'cashflow_type': None,
-            'pay_date': None,
-            'effective_date': None,
-            'currency': None,
-            'amount': None,
-            'long_short': None
-        }

--- a/src/domainobjects/swap_contract.py
+++ b/src/domainobjects/swap_contract.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import datetime, timedelta
 from domainobjects.generatable import Generatable
 
+
 class SwapContract(Generatable):
     """ Class to generate swap contracts. Generate method will generate a set
     of swap contracts. Other generation methods are included where swap
@@ -59,34 +60,33 @@ class SwapContract(Generatable):
             A single swap contract object
         """
 
-        record = self.instantiate_record()
-
         status = self.generate_status()
         start_date = self.generate_random_date()
         contract_id = str(uuid.uuid1())
         self.persist_record([contract_id])
 
-        record['counterparty_id'] = counterparty
-        record['swap_contract_id'] = contract_id
-        record['swap_mnemonic'] = self.generate_random_string(10)
-        record['is_short_mtm_financed'] = self.generate_random_boolean()
-        record['accounting_area'] = self.generate_random_string(10)
-        record['status'] = status
-        record['start_date'] = start_date
-        record['end_date'] = self.generate_swap_end_date(
+        record = {
+            'counterparty_id': counterparty,
+            'swap_contract_id': contract_id,
+            'swap_mnemonic': self.generate_random_string(10),
+            'is_short_mtm_financed': self.generate_random_boolean(),
+            'accounting_area': self.generate_random_string(10),
+            'status': status,
+            'start_date': start_date,
+            'end_date': self.generate_swap_end_date(
                                     start_date=start_date,
-                                    status=status)
-        record['swap_type'] = self.generate_swap_type()
-        record['reference_rate'] = self.generate_reference_rate()
-        record['swap_contract_field1'] = self.generate_random_string(10)
-        record['swap_contract_field2'] = self.generate_random_string(10)
-        record['swap_contract_field3'] = self.generate_random_string(10)
-        record['swap_contract_field4'] = self.generate_random_string(10)
-        record['swap_contract_field5'] = self.generate_random_string(10)
-        record['swap_contract_field6'] = self.generate_random_string(10)
-        record['swap_contract_field7'] = self.generate_random_string(10)
-        record['swap_contract_field8'] = self.generate_random_string(10)
-        record['time_stamp'] = datetime.now()
+                                    status=status),
+            'swap_type': self.generate_swap_type(),
+            'reference_rate': self.generate_reference_rate(),
+            'time_stamp': datetime.now()
+        }
+
+        # for loop below can be easily changed to iterate over
+        # range(1, num_contracts + 1) where num_contracts is provided in
+        # config.json if we want to let users customise output in this way
+        for index in range(1, 9):
+            record[f'swap_contract_field{index}'] =\
+                self.generate_random_string(10)
 
         return record
 
@@ -164,25 +164,3 @@ class SwapContract(Generatable):
         """
 
         return random.choice(['Live', 'Dead'])
-
-    def instantiate_record(self):
-        return {
-            'counterparty_id': None,
-            'swap_contract_id': None,
-            'swap_mnemonic': None,
-            'accounting_area': None,
-            'status': None,
-            'start_date': None,
-            'end_date': None,
-            'swap_type': None,
-            'reference_rate': None,
-            'swap_contract_field1': None,
-            'swap_contract_field2': None,
-            'swap_contract_field3': None,
-            'swap_contract_field4': None,
-            'swap_contract_field5': None,
-            'swap_contract_field6': None,
-            'swap_contract_field7': None,
-            'swap_contract_field8': None,
-            'time_stamp': None
-        }

--- a/src/domainobjects/swap_position.py
+++ b/src/domainobjects/swap_position.py
@@ -1,8 +1,9 @@
 from domainobjects.generatable import Generatable
-from datetime import datetime, timedelta
+from datetime import datetime
 import random
 import string
 import pandas as pd
+
 
 class SwapPosition(Generatable):
     """ Class to generate swap positions. Generate method will generate a set
@@ -58,19 +59,25 @@ class SwapPosition(Generatable):
 
         Parameters
         ----------
-        Swap Position : dict
-            Dictionary containing a partial record of a swap contract, only
-            contains the information necessary to generate swap positions
-        cf_arg : dict
-            Dictionary defining the particular swap position being generated
-            for
+        swap_contract : dict
+            Swap contract domain object record
+
+        instrument : dict
+            Instrument domain object record
+
+        position_type : string
+            One of 'S', 'I', or 'E'
+
+        date : datetime
+            Randomly selected date that falls between the user-specified start
+            date and the current date
 
         Returns
         -------
         dict
             A single swap position object
         """
-        record = self.instantiate_record()
+
         long_short = self.generate_long_short()
         purpose = self.generate_purpose()
         quantity = self.generate_random_integer(
@@ -78,18 +85,7 @@ class SwapPosition(Generatable):
                     )
         current_date = datetime.strftime(date, '%Y-%m-%d')
 
-        record['swap_contract_id'] = swap_contract['id']
-        record['ric'] = instrument['ric']
-        record['long_short'] = long_short
-        record['purpose'] = purpose
-        record['td_quantity'] = quantity
-        record['position_type'] = position_type
-        record['knowledge_date'] = current_date
-        record['effective_date'] = current_date
-        record['account'] = self.generate_account()
-        record['time_stamp'] = datetime.now()
-
-        if (position_type == 'E'):
+        if position_type == 'E':
             self.persist_record(
                 [str(swap_contract['id']),
                  instrument['ric'],
@@ -98,7 +94,18 @@ class SwapPosition(Generatable):
                  str(long_short)]
             )
 
-        return record
+        return {
+            'ric': instrument['ric'],
+            'swap_contract_id': swap_contract['id'],
+            'position_type': position_type,
+            'knowledge_date': current_date,
+            'effective_date': current_date,
+            'account': self.generate_account(),
+            'long_short': long_short,
+            'td_quantity': quantity,
+            'purpose': purpose,
+            'time_stamp': datetime.now()
+        }
 
     def get_random_instruments(self):
         """ Retrieves a random batch of instruments
@@ -174,17 +181,3 @@ class SwapPosition(Generatable):
         """
 
         return random.choice(self.PURPOSES)
-
-    def instantiate_record(self):
-        return {
-            'ric': None,
-            'swap_contract_id': None,
-            'position_type': None,
-            'knowledge_date': None,
-            'effective_date': None,
-            'account': None,
-            'long_short': None,
-            'td_quantity': None,
-            'purpose': None,
-            'time_stamp': None
-        }


### PR DESCRIPTION
closes #162 

In each of cashflow.py, swap_position.py and swap_contract.py, the instantiate_record method was removed and generate_record was refactored accordingly (see issue 162 for reasons why)

Some formatting housekeeping was carried out in the process to keep in line with PEP8 such as adding blank lines between functions and at the end of files.

Two notable changes were made that were not in the original issue, as they were considered relevant enough to include in this PR:

- The docstring for generate_record in swap_position.py was out of date and did not match the current parameters, so it was corrected
- A timedelta import in swap_position.py was removed as the module was never used

All tests pass and app.py outputs are as expected